### PR TITLE
feat: Add Dockerized deployment with Traefik reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,70 @@
 
 # Visual Search LTI App
 
-This is a Node.js/ltijs-based LTI 1.3 tool with Dockerized MongoDB and environment-driven configuration.
+Node.js/ltijs-based LTI 1.3 tool with Dockerized deployment, Traefik reverse proxy, and environment-driven configuration.
 
-## Quick Start
+## Quick Start (Development)
 
-1. **Clone the repo**
-2. **Configure environment variables**
-  - Copy `.env.example` to `.env` and set all required values (MongoDB, LTI, tool provider, etc.)
-3. **Start MongoDB (Docker)**
-  - `docker compose up -d`
-4. **Install dependencies**
-  - `npm install`
-5. **Run the app**
-  - `npm start` or `node index.js`
+1. **Clone and configure**
+   ```bash
+   git clone <repo-url>
+   cd visual-search-lti-app
+   cp .env.dev .env  # Use development settings
+   ```
+
+2. **Start services**
+   ```bash
+   # For development (HTTP, local testing)
+   docker compose -f docker-compose.dev.yml up --build
+   
+   # For production-like testing (HTTPS)
+   docker compose up --build
+   ```
+
+3. **Access**
+   - App: http://localhost:3000 (dev) or http://localhost (prod)
+   - Traefik Dashboard: http://localhost/dashboard/ (admin/admin)
+
+## Production Deployment
+
+1. **Set production environment**
+   ```bash
+   cp .env.prod .env
+   # Update APP_DOMAIN, TRAEFIK_ACME_EMAIL, and all credentials
+   ```
+
+2. **Deploy with HTTPS**
+   ```bash
+   docker compose up -d --build
+   ```
+
+3. **Access**
+   - App: https://yourdomain.com
+   - Dashboard: https://yourdomain.com/dashboard/
 
 ## Environment Variables
-All secrets and config are managed via `.env`, `.env.dev`, `.env.prod`.
-See `.env.example` for all available options.
 
-## Docker
-MongoDB is managed via Docker Compose. All credentials are set via environment variables.
+**Required:**
+- `DB_USER`, `DB_PASS`, `DB_NAME` - MongoDB credentials
+- `LTI_KEY` - JWT secret for LTI
+- `APP_DOMAIN` - Your domain name
+- `TRAEFIK_ACME_EMAIL` - Email for SSL certificates
+- `TOOL_PROVIDER_*` - LTI tool configuration
 
-## LTI Platform Registration
-Platforms are registered automatically on startup. See `index.js` for details.
+**Config Files:**
+- `.env.dev` - Development (HTTP, direct access)
+- `.env.prod` - Production (HTTPS, domain-based)
 
-## Frontend
-The React frontend is served from the `public` directory. No secrets are hardcoded in frontend files.
+## Architecture
+
+- **MongoDB** - Database with authentication
+- **Node.js App** - LTI 1.3 provider on port 3000
+- **Traefik** - Reverse proxy with SSL termination
+
+## Features
+
+- LTI 1.3 dynamic registration
+- Grade passback with comments
+- Dockerized deployment
+- HTTPS with Let's Encrypt
+- Password-protected admin dashboard

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,8 +27,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.lti-app.rule=Host(`${APP_DOMAIN}`)"
-      - "traefik.http.routers.lti-app.entrypoints=websecure"
-      - "traefik.http.routers.lti-app.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.lti-app.entrypoints=web"
       - "traefik.http.services.lti-app.loadbalancer.server.port=3000"
     networks:
       - db-network
@@ -39,37 +38,27 @@ services:
     restart: unless-stopped
     command:
       - --api.dashboard=true
-      - --api.insecure=false
+      - --api.insecure=true
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
-      - --entrypoints.websecure.address=:443
-      - --certificatesresolvers.letsencrypt.acme.email=${TRAEFIK_ACME_EMAIL}
-      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
-      - --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web
-      - --providers.file.filename=/etc/traefik/traefik.yml
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.dashboard.rule=Host(`${APP_DOMAIN}`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
-      - "traefik.http.routers.dashboard.entrypoints=websecure"
-      - "traefik.http.routers.dashboard.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.dashboard.entrypoints=web"
       - "traefik.http.routers.dashboard.middlewares=dashboard-auth"
       - "traefik.http.middlewares.dashboard-auth.basicauth.users=${TRAEFIK_DASHBOARD_AUTH}"
       - "traefik.http.routers.dashboard.service=api@internal"
     ports:
       - "80:80"
-      - "443:443"
+      - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - traefik_letsencrypt:/letsencrypt
-      - ./docker/traefik.yml:/etc/traefik/traefik.yml:ro
     networks:
       - db-network
 
-
 volumes:
   mongo_data:
-  traefik_letsencrypt:
 
 networks:
   db-network:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+# Node.js server Dockerfile
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["node", "index.js"]

--- a/docker/traefik.yml
+++ b/docker/traefik.yml
@@ -1,0 +1,27 @@
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+
+api:
+  dashboard: true
+
+providers:
+  docker:
+    exposedByDefault: false
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: ${TRAEFIK_ACME_EMAIL}
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+
+# Dashboard authentication middleware
+middlewares:
+  dashboard-auth:
+    basicAuth:
+      users:
+        - ${TRAEFIK_DASHBOARD_USER}


### PR DESCRIPTION
- Dockerize Node.js backend with production-ready setup
- Add Traefik for HTTPS, reverse proxy, and dashboard authentication
- Organize Docker files in docker/ directory structure
- Support both development and production deployment modes
- Environment-driven configuration for all services
- Password-protected Traefik dashboard with admin credentials
- Let's Encrypt SSL certificate automation for production
- Updated README with clear dev/prod deployment instructions